### PR TITLE
The index.html references are redundant.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,14 +31,14 @@
               <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
             </section>
           {% endif %}
-		  <a class="button" href="/index.html">Home</a>
-		  <a class="button" href="/projects/index.html">Projects</a>
-		  <a class="button" href="/license/index.html">License</a>
-		  <a class="button" href="/posts/index.html">Posts</a>
-		  <a class="button" href="/tips/index.html">Project Managers</a>
-		  <a class="button" href="/newproject/index.html">Add a Project</a>
-		  <a class="button" href="/admin/index.html">Admin</a>
-		  <a class="button" href="/about/index.html">About</a>
+		  <a class="button" href="/">Home</a>
+		  <a class="button" href="/projects/">Projects</a>
+		  <a class="button" href="/license/">License</a>
+		  <a class="button" href="/posts/">Posts</a>
+		  <a class="button" href="/tips/">Project Managers</a>
+		  <a class="button" href="/newproject/">Add a Project</a>
+		  <a class="button" href="/admin/">Admin</a>
+		  <a class="button" href="/about/">About</a>
         </header>
     </div>
 


### PR DESCRIPTION
`index.html` is the default document on Github.